### PR TITLE
Stop relying on Everest hackfix for zip mover textures

### DIFF
--- a/Code/Entities/LinkedZipMover.cs
+++ b/Code/Entities/LinkedZipMover.cs
@@ -49,7 +49,7 @@ namespace Celeste.Mod.AdventureHelper.Entities {
             ropeLightColor = Calc.HexToColor(ColorCode) * 1.1f;
             Add(new Coroutine(Sequence(), true));
             Add(new LightOcclude(1f));
-            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0).AtlasPath != "__fallback" ? spritePath + "/light" : "objects/zipmover/light"));
+            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0)?.AtlasPath is not ("__fallback" or null) ? spritePath + "/light" : "objects/zipmover/light"));
             streetlight.Add("frames", "", 1f);
 
             streetlight.Play("frames");

--- a/Code/Entities/LinkedZipMover.cs
+++ b/Code/Entities/LinkedZipMover.cs
@@ -49,13 +49,8 @@ namespace Celeste.Mod.AdventureHelper.Entities {
             ropeLightColor = Calc.HexToColor(ColorCode) * 1.1f;
             Add(new Coroutine(Sequence(), true));
             Add(new LightOcclude(1f));
-            try {
-                Add(streetlight = new Sprite(GFX.Game, spritePath + "/light"));
-                streetlight.Add("frames", "", 1f);
-            } catch {
-                Add(streetlight = new Sprite(GFX.Game, "objects/zipmover/light"));
-                streetlight.Add("frames", "", 1f);
-            }
+            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0).AtlasPath != "__fallback" ? spritePath + "/light" : "objects/zipmover/light"));
+            streetlight.Add("frames", "", 1f);
 
             streetlight.Play("frames");
             streetlight.Active = false;

--- a/Code/Entities/LinkedZipMoverNoReturn.cs
+++ b/Code/Entities/LinkedZipMoverNoReturn.cs
@@ -53,7 +53,7 @@ namespace Celeste.Mod.AdventureHelper.Entities {
             firstDirection = true;
             Add(new Coroutine(Sequence(), true));
             Add(new LightOcclude(1f));
-            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0).AtlasPath != "__fallback" ? spritePath + "/light" : "objects/zipmover/light"));
+            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0)?.AtlasPath is not ("__fallback" or null) ? spritePath + "/light" : "objects/zipmover/light"));
             streetlight.Add("frames", "", 1f);
 
             streetlight.Play("frames");

--- a/Code/Entities/LinkedZipMoverNoReturn.cs
+++ b/Code/Entities/LinkedZipMoverNoReturn.cs
@@ -53,13 +53,8 @@ namespace Celeste.Mod.AdventureHelper.Entities {
             firstDirection = true;
             Add(new Coroutine(Sequence(), true));
             Add(new LightOcclude(1f));
-            try {
-                Add(streetlight = new Sprite(GFX.Game, spritePath + "/light"));
-                streetlight.Add("frames", "", 1f);
-            } catch {
-                Add(streetlight = new Sprite(GFX.Game, "objects/zipmover/light"));
-                streetlight.Add("frames", "", 1f);
-            }
+            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0).AtlasPath != "__fallback" ? spritePath + "/light" : "objects/zipmover/light"));
+            streetlight.Add("frames", "", 1f);
 
             streetlight.Play("frames");
             streetlight.Active = false;

--- a/Code/Entities/ZipMoverNoReturn.cs
+++ b/Code/Entities/ZipMoverNoReturn.cs
@@ -54,7 +54,7 @@ namespace Celeste.Mod.AdventureHelper.Entities {
             firstDirection = true;
             Add(new Coroutine(Sequence(), true));
             Add(new LightOcclude(1f));
-            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0).AtlasPath != "__fallback" ? spritePath + "/light" : "objects/zipmover/light"));
+            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0)?.AtlasPath is not ("__fallback" or null) ? spritePath + "/light" : "objects/zipmover/light"));
             streetlight.Add("frames", "", 1f);
 
             streetlight.Play("frames");

--- a/Code/Entities/ZipMoverNoReturn.cs
+++ b/Code/Entities/ZipMoverNoReturn.cs
@@ -54,13 +54,8 @@ namespace Celeste.Mod.AdventureHelper.Entities {
             firstDirection = true;
             Add(new Coroutine(Sequence(), true));
             Add(new LightOcclude(1f));
-            try {
-                Add(streetlight = new Sprite(GFX.Game, spritePath + "/light"));
-                streetlight.Add("frames", "", 1f);
-            } catch {
-                Add(streetlight = new Sprite(GFX.Game, "objects/zipmover/light"));
-                streetlight.Add("frames", "", 1f);
-            }
+            Add(streetlight = new Sprite(GFX.Game, GFX.Game.GetAtlasSubtexturesAt(spritePath + "/light", 0).AtlasPath != "__fallback" ? spritePath + "/light" : "objects/zipmover/light"));
+            streetlight.Add("frames", "", 1f);
 
             streetlight.Play("frames");
             streetlight.Active = false;


### PR DESCRIPTION
For determining when to use default zip mover textures, Adventure Helper used to rely on exceptions being thrown, which stopped working when the fallback texture was introduced in Everest. Everest has a [hackfix](https://github.com/EverestAPI/Everest/blob/dev/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs#L156) to deal with this. Adventure Helper was partially fixed in [this commit](https://github.com/acsBenceTamas/Kayden-Fox-Celeste-Mods/commit/5e4c792fb0fee8cee457ecf78dcec648d3542cac), but not completely. This removes the remaining try-catches so that the Everest hackfix becomes obsolete and can be removed.